### PR TITLE
add command to dim brightness of led

### DIFF
--- a/lib/Shared/Config.h
+++ b/lib/Shared/Config.h
@@ -36,4 +36,5 @@ struct Configuration {
 	SensorConfig sensors[SENSOR_COUNT];
 	bool sdDebug = false;
 	Extra extra;
+	float dimled;
 };

--- a/sam/src/Commands.cpp
+++ b/sam/src/Commands.cpp
@@ -730,3 +730,18 @@ void custom_mqtt_com(SckBase* base, String parameters)
 	uint8_t mfourth = parameters.indexOf("'", mthird + 1);
 	base->mqttCustom(parameters.substring(mfirst + 1, msecond).c_str(), parameters.substring(mthird + 1, mfourth).c_str());
 }
+void dimled_com(SckBase* base, String parameters)
+{
+	if (parameters.length() > 0) {
+		float newDim = parameters.toFloat();
+		if (newDim >= 0 && newDim <= 1) {
+			base->led.dim = newDim;
+			base->led.tick();
+		} else {
+			base->sckOut("illegal value");
+			return;
+		}
+	}
+	sprintf(base->outBuff, "LED brightness level: %.2f", base->led.dim);
+	base->sckOut();
+}

--- a/sam/src/Commands.cpp
+++ b/sam/src/Commands.cpp
@@ -597,6 +597,12 @@ void config_com(SckBase* base, String parameters)
 					base->config.token.set = true;
 				}
 			}
+			uint16_t dimledI = parameters.indexOf("-dimled");
+			if (dimledI >= 0) {
+				String dimledC = parameters.substring(dimledI+8);
+				float dimledV = dimledC.toFloat();
+				if (dimledV >= 0 && dimledV <= 1) base->config.dimled = dimledV;
+			}
 			base->saveConfig();
 		}
 		sprintf(base->outBuff, "-- New config --\r\n");
@@ -617,7 +623,8 @@ void config_com(SckBase* base, String parameters)
 	if (currentConfig.token.set) sprintf(base->outBuff, "%s%s\r\n", base->outBuff, currentConfig.token.token);
 	else sprintf(base->outBuff, "%snot configured\r\n", base->outBuff);
 
-	sprintf(base->outBuff, "%sMac address:  %s", base->outBuff, base->config.mac.address);
+	sprintf(base->outBuff, "%sMac address:  %s\r\n", base->outBuff, base->config.mac.address);
+	sprintf(base->outBuff, "%sLED brightness level: %.2f", base->outBuff, base->config.dimled);
 	base->sckOut();
 }
 void esp_com(SckBase* base, String parameters)
@@ -729,19 +736,4 @@ void custom_mqtt_com(SckBase* base, String parameters)
 	uint8_t mthird = parameters.indexOf("'", msecond + 1);
 	uint8_t mfourth = parameters.indexOf("'", mthird + 1);
 	base->mqttCustom(parameters.substring(mfirst + 1, msecond).c_str(), parameters.substring(mthird + 1, mfourth).c_str());
-}
-void dimled_com(SckBase* base, String parameters)
-{
-	if (parameters.length() > 0) {
-		float newDim = parameters.toFloat();
-		if (newDim >= 0 && newDim <= 1) {
-			base->led.dim = newDim;
-			base->led.tick();
-		} else {
-			base->sckOut("illegal value");
-			return;
-		}
-	}
-	sprintf(base->outBuff, "LED brightness level: %.2f", base->led.dim);
-	base->sckOut();
 }

--- a/sam/src/Commands.h
+++ b/sam/src/Commands.h
@@ -33,7 +33,6 @@ enum CommandType {
 	COM_DEBUG,
 	COM_SHELL,
 	COM_CUSTOM_MQTT,
-	COM_DIMLED,
 
 	COM_COUNT
 };
@@ -63,7 +62,6 @@ void debug_com(SckBase* base, String parameters);
 void shell_com(SckBase* base, String parameters);
 void custom_mqtt_com(SckBase* base, String parameters);
 void ramGet_com(SckBase* base, String parameters);
-void dimled_com(SckBase* base, String parameters);
 
 typedef void (*com_function)(SckBase* , String);
 
@@ -104,7 +102,7 @@ class AllCommands {
 			OneCom {90,	COM_GET_FREERAM,	"free",		"Shows the amount of free RAM memory",													freeRAM_com},
 			OneCom {90,	COM_I2C_DETECT,		"i2c",		"Search the I2C bus for devices",													i2cDetect_com},
 			OneCom {90,	COM_CHARGER,		"charger",	"Controls or shows charger configuration [-otg on/off] [-charge on/off]",								charger_com},
-			OneCom {90,	COM_CONFIG,		"config",	"Shows/sets configuration [-defaults] [-mode sdcard/network] [-pubint seconds] [-readint seconds] [-wifi \"ssid\" [\"pass\"]] [-token token]", config_com},
+			OneCom {90,	COM_CONFIG,		"config",	"Shows/sets configuration [-defaults] [-mode sdcard/network] [-pubint seconds] [-readint seconds] [-wifi \"ssid\" [\"pass\"]] [-token token] [-dimled float]", config_com},
 			OneCom {100,	COM_ESP_CONTROL,	"esp",		"Controls or shows info from ESP [-on -off -sleep -wake -reboot -flash]",								esp_com},
 			OneCom {100,	COM_NETINFO,		"netinfo",	"Shows network information",														netInfo_com},
 			OneCom {100,	COM_TIME,		"time",		"Shows/sets time [epoch time] [-sync]",													time_com},
@@ -113,7 +111,6 @@ class AllCommands {
 			OneCom {100,	COM_DEBUG, 		"debug", 	"Toggle debug messages [-sdcard] [-espcom] [-list]", 												debug_com},
 			OneCom {100,	COM_SHELL, 		"shell", 	"Shows or sets shell mode [-on] [-off]",												shell_com},
 			OneCom {100,	COM_CUSTOM_MQTT,	"mqtt", 	"Publish custom mqtt message ('topic' 'message')",											custom_mqtt_com},
-			OneCom {100,	COM_DIMLED,		"dimled", 	"Show/set brightness of LED [float]",													dimled_com},
 		};
 
 		OneCom & operator[](CommandType type) {

--- a/sam/src/Commands.h
+++ b/sam/src/Commands.h
@@ -33,6 +33,7 @@ enum CommandType {
 	COM_DEBUG,
 	COM_SHELL,
 	COM_CUSTOM_MQTT,
+	COM_DIMLED,
 
 	COM_COUNT
 };
@@ -62,6 +63,7 @@ void debug_com(SckBase* base, String parameters);
 void shell_com(SckBase* base, String parameters);
 void custom_mqtt_com(SckBase* base, String parameters);
 void ramGet_com(SckBase* base, String parameters);
+void dimled_com(SckBase* base, String parameters);
 
 typedef void (*com_function)(SckBase* , String);
 
@@ -111,6 +113,7 @@ class AllCommands {
 			OneCom {100,	COM_DEBUG, 		"debug", 	"Toggle debug messages [-sdcard] [-espcom] [-list]", 												debug_com},
 			OneCom {100,	COM_SHELL, 		"shell", 	"Shows or sets shell mode [-on] [-off]",												shell_com},
 			OneCom {100,	COM_CUSTOM_MQTT,	"mqtt", 	"Publish custom mqtt message ('topic' 'message')",											custom_mqtt_com},
+			OneCom {100,	COM_DIMLED,		"dimled", 	"Show/set brightness of LED [float]",													dimled_com},
 		};
 
 		OneCom & operator[](CommandType type) {

--- a/sam/src/SckBase.cpp
+++ b/sam/src/SckBase.cpp
@@ -714,6 +714,7 @@ void SckBase::loadConfig()
 	st.tokenSet = config.token.set;
 	st.tokenError = false;
 	st.mode = config.mode;
+	led.dim = config.dimled;
 
 	// CSS vocs sensor baseline loading
 	if (config.extra.ccsBaselineValid && I2Cdetect(&Wire, urban.sck_ccs811.address)) {
@@ -743,6 +744,7 @@ void SckBase::saveConfig(bool defaults)
 			config.sensors[i].enabled = sensors[static_cast<SensorType>(i)].defaultEnabled;
 			config.sensors[i].everyNint = 1;
 		}
+		config.dimled = 1.0;
 		pendingSyncConfig = true;
 	} else {
 		for (uint8_t i=0; i<SENSOR_COUNT; i++) {
@@ -762,6 +764,7 @@ void SckBase::saveConfig(bool defaults)
 	st.wifiStat.reset();
 	lastPublishTime = rtc.getEpoch() - config.publishInterval;
 	lastSensorUpdate = rtc.getEpoch() - config.readInterval;
+	led.dim = config.dimled;
 
 	if (st.wifiSet || st.tokenSet) pendingSyncConfig = true;
 

--- a/sam/src/SckLed.cpp
+++ b/sam/src/SckLed.cpp
@@ -44,7 +44,15 @@ void SckLed::update(ColorName colorName, pulseModes pulse, bool force)
 void SckLed::tick()
 {
 
-	if (pulseMode == PULSE_SOFT) {
+	if (dim == 0) {
+		pinMode(pinRED, OUTPUT);
+		pinMode(pinGREEN, OUTPUT);
+		pinMode(pinBLUE, OUTPUT);
+		digitalWrite(pinRED, 1);
+		digitalWrite(pinGREEN, 1);
+		digitalWrite(pinBLUE, 1);
+		disableTimer5();
+	} else if (pulseMode == PULSE_SOFT) {
 		Color c = *(currentPulse + colorIndex);
 
 		if (chargeStatus == CHARGE_CHARGING) {
@@ -58,21 +66,21 @@ void SckLed::tick()
 			else c = *(currentPulse + 24);
 		}
 
-		analogWrite(pinRED, 255 - c.r);
-		analogWrite(pinGREEN, 255 - c.g);
-		analogWrite(pinBLUE, 255 - c.b);
+		analogWrite(pinRED, 255 - round(c.r * dim));
+		analogWrite(pinGREEN, 255 - round(c.g * dim));
+		analogWrite(pinBLUE, 255 - round(c.b * dim));
 		if (colorIndex == 24) direction = -1;
 		else if (colorIndex == 0) direction = 1;
 		colorIndex += direction; 
 	} else if (pulseMode == PULSE_STATIC) { 
-		analogWrite(pinRED, 255 - ledColor.r);
-		analogWrite(pinGREEN, 255 - ledColor.g);
-		analogWrite(pinBLUE, 255 - ledColor.b);
+		analogWrite(pinRED, 255 - round(ledColor.r * dim));
+		analogWrite(pinGREEN, 255 - round(ledColor.g * dim));
+		analogWrite(pinBLUE, 255 - round(ledColor.b * dim));
 	} else {
 		if (blinkON) {
-			analogWrite(pinRED, 255 - ledColor.r);
-			analogWrite(pinGREEN, 255 - ledColor.g);
-			analogWrite(pinBLUE, 255 - ledColor.b);
+			analogWrite(pinRED, 255 - round(ledColor.r * dim));
+			analogWrite(pinGREEN, 255 - round(ledColor.g * dim));
+			analogWrite(pinBLUE, 255 - round(ledColor.b * dim));
 		} else {
 			pinMode(pinRED, OUTPUT);
 			pinMode(pinGREEN, OUTPUT);

--- a/sam/src/SckLed.h
+++ b/sam/src/SckLed.h
@@ -48,6 +48,8 @@ public:
 	// Powerfeedback
 	ChargeStatus chargeStatus = CHARGE_NULL;
 
+	float dim = 1.0;
+
 private:
 
 	/* void setRGBColor(Color myColor); */


### PR DESCRIPTION
As mentioned in https://forum.smartcitizen.me/t/disable-led-for-indoor-use/1150 I was also interested in a way to darken or disable LEDs.

~I implemented a command to crudely dim the brightness of the status LED.~ I would love to be able to also dim the USB and WiFi LEDs but right now I have no idea how to interface with ~the ESP or~ the bootloader (I also don't have the means to flash the bootloader).  ~Also, if one sets the brightness level to 0.0 and then back up to anything else, the pulse animation won't continue because I killed the timer and was too lazy to implement that case. I can change that if requested.~ EDIT: By storing `dimled` in `Configuration` I fixed some of the problems and also have an idea how to interface with the ESP now.

This was tested on one of my own SCK2.1.

Would be happy about any feedback.